### PR TITLE
Updated Lambda function to use the nodejs 12.x runtime

### DIFF
--- a/ohdsi-install-server.yaml
+++ b/ohdsi-install-server.yaml
@@ -235,7 +235,7 @@ Resources:
               return failed({Error: "In-place updates not supported."});
             }
           };
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 300
   LambdaExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
The older 8.10 nodejs runtime is no longer supported