### PR TITLE
Update Windows AMI and Lambda custom resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## OHDSI-Install-Server
 
-OHDSI-Install-Server is specifically created as a learning environment, and is used in the OHDSI Tools course in the [EHDEN academy](https://academy.ehden.eu). This course provides training on how to install all the OHDSI tools. The server only includes Postgres and Notepad++ and the goal for the student is to install all the OHDSI tools.
+OHDSI-Install-Server is specifically created as a learning environment, and is used in the OHDSI Tools course in the [EHDEN academy](https://academy.ehden.eu). This course provides training on how to install all the OHDSI tools. The current CloudFormation template launches an Amazon Windows Server 2025 Full Base AMI; students should install the required OHDSI tools as part of the training.
 
 Note that if you are looking to deploy the environment with all tools installed check out the [OHDSI-In-Box project](https://github.com/OHDSI/OHDSI-In-A-box). There is also an enterprise, scalable OHDSI architecture created in the [OHDSIonAWS project](https://github.com/OHDSI/OHDSIonAWS).  
 
@@ -8,20 +8,15 @@ Note that if you are looking to deploy the environment with all tools installed 
 | --- | --- | ---
 | eu-west-1 |EU (Ireland)| [![cloudformation-launch-stack](images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=OHDSI&templateURL=https://ohdsi-in-a-box-build.s3-eu-west-1.amazonaws.com/ohdsi-install-server.yaml) |
 
-This server has the following components installed:
+This server uses the following base image:
 
-| Software | Version |
+| Component | Version |
 | --- | ---
-| Postgres | 10.9 |
-| Notepad++ | 7.7.1 |
+| Windows Server | 2025 English Full Base |
 
-**Windows username:** ohdsi
+**Windows username:** Administrator
 
 **Windows password:** this is specified as a parameter during deployment
-
-**Postgres username:** postgres
-
-**Postgres password:** ohdsi
 
 
 ## OHDSI-Install-Server deployment instructions
@@ -67,7 +62,7 @@ When you've provided appropriate values for the **Parameters**, choose **Next**.
 
 ![alt-text](images/cfn_output.gif "CloudFormation Output")
 
-6.  You will now see a list of all of your OHDSI-Install-Server instances and you can connect to them using your Remote Desktop client, the username **ohdsi** and the password you provided as a parameter.  It will take about 5 minutes after this list appears for each OHDSI-Install-Server instance to boot up and for the password to be set.  If you connect to your instance and it says the password is incorrect, just wait a few more minutes for the password automation to complete.
+6.  You will now see a list of all of your OHDSI-Install-Server instances and you can connect to them using your Remote Desktop client, the username **Administrator** and the password you provided as a parameter. Leave the domain field empty, or use `.\Administrator` if your RDP client requires a local-account prefix. It will take about 5 minutes after this list appears for each OHDSI-Install-Server instance to boot up and for the password to be set. If you connect to your instance and it says the password is incorrect, just wait a few more minutes for the password automation to complete. The template also creates an **ohdsi** local administrator account with the same password.
 
 7.  Once you are finished with your OHDSI-Install-Server instances, just return to the AWS CloudFormation console and **Delete** the stack, as shown below.  This will terminate all of the instances you launched.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ This server uses the following base image:
 
 **Windows password:** this is specified as a parameter during deployment
 
+### Additional software to install
+
+The template starts from a clean Windows Server base image. It does not pre-install PostgreSQL, Notepad++, or the OHDSI tool stack. After connecting over RDP, install the course prerequisites manually:
+
+- [PostgreSQL for Windows](https://www.postgresql.org/download/windows/) - use the Windows installer linked from PostgreSQL.
+- [Notepad++ downloads](https://notepad-plus-plus.org/downloads/) - use the current installer, or the course-specific version if required.
+- [The Book of OHDSI](https://ohdsi.github.io/TheBookOfOhdsi/) - reference material for the OHDSI tools and setup workflow.
 
 ## OHDSI-Install-Server deployment instructions
 
@@ -26,17 +33,19 @@ This server uses the following base image:
 **Mac OS X** Download the Microsoft Remote Desktop app from the Mac App Store.
 **Linux** Use [rdesktop](http://www.rdesktop.org/).
 
-1. Begin the deployment process by clicking the **Launch Stack** button at the top of this page.  This will take you to the [CloudFormation Manage Console](https://console.aws.amazon.com/cloudformation/) and specify the OHDSI Cloudformation template URL (https://OHDSI-Install-Server-build.s3-eu-west-1.amazonaws.com/ohdsi-install-server.yaml).  In the top-right corner of the console, choose the EU Ireland AWS Region, and then click **Next**. Note that at the moment you can only deploy in this region.
+1. Begin the deployment process by clicking the **Launch Stack** button at the top of this page.  This will take you to the [CloudFormation Manage Console](https://console.aws.amazon.com/cloudformation/) and specify the OHDSI Cloudformation template URL (<https://OHDSI-Install-Server-build.s3-eu-west-1.amazonaws.com/ohdsi-install-server.yaml>).  In the top-right corner of the console, choose the EU Ireland AWS Region, and then click **Next**. Note that at the moment you can only deploy in this region.
 
-2. The next screen will take in all of the parameters for your OHDSI environment.  A description is provided for each parameter to help explain its function, but following is also a detailed description of how to use each parameter.  At the top, provide a unique **Stack Name**.   
+2. The next screen will take in all of the parameters for your OHDSI environment.  A description is provided for each parameter to help explain its function, but following is also a detailed description of how to use each parameter.  At the top, provide a unique **Stack Name**.
 
 #### Security
+
 |Parameter Name| Description|
 |---------------|-----------|
 | Instance Password | **Required** This password will be used to allow you to login to the OHDSI-Install-Server instance.  It can contain upper and lowercase letters, numbers, and/or these special characters !@# |
 | Limit access to IP address range? | **Required** This parameter allows you to limit the IP address range that can access your Atlas and RStudio servers. It uses CIDR notation. The default of 0.0.0.0/0 will allow access from any address.|
 
 #### Scaling
+
 |Parameter Name| Description|
 |---------------|-----------|
 | Number of OHDSI-Install-Servers instances to deploy | This determines the number of OHDSI-Install-Server instances that will be deployed.  This allows you to easily deploy more than 1 instance if you are using it for a virtual training environment. |
@@ -45,6 +54,7 @@ This server uses the following base image:
 | Disk space for each OHDSI-Install-Server instance | This defines the disk size of the OHDSI-Install-Server instance in GBs.  The minimum size is 100GB and the maximum size is 16,000GB (or 16TB).  You can use this parameter to deploy additional disk space in order to upload your own data into your OHDSI-Install-Server instance. |
 
 #### Networking
+
 |Parameter Name| Description|
 |---------------|-----------|
 | Subnet | This is the subnet within an AWS VPC into which all of your instances will be deployed.  If you aren't familiar with this setting, you can choose a subnet from within your Default VPC.  They typically have a name like **subnet-111111a (172.31.0.0/20)** |
@@ -52,19 +62,19 @@ This server uses the following base image:
 
 When you've provided appropriate values for the **Parameters**, choose **Next**.
 
-3. On the next screen, you can provide some other optional information like tags at your discretion, or just choose **Next**.
+1. On the next screen, you can provide some other optional information like tags at your discretion, or just choose **Next**.
 
-4. On the next screen, you can review what will be deployed.  Be sure to check the box that says **I acknowledge that AWS CloudFormation might create IAM resources.** as shown in the image below.  Then choose **Create**.
+2. On the next screen, you can review what will be deployed.  Be sure to check the box that says **I acknowledge that AWS CloudFormation might create IAM resources.** as shown in the image below.  Then choose **Create**.
 
 ![alt-text](images/acknowledge.png "Acknowledge")
 
-5. You can watch as CloudFormation builds out your OHDSI environment. A CloudFormation deployment is called a *stack*. The parent stack creates several child stacks depending on the parameters you provided.  When all the stacks have reached the green CREATE_COMPLETE status, as shown in the screenshot following, then the OHDSI architecture has been deployed.  Select the **Outputs** tab to find a link to your OHDSI-Install-Server instances, as shown below.
+1. You can watch as CloudFormation builds out your OHDSI environment. A CloudFormation deployment is called a *stack*. The parent stack creates several child stacks depending on the parameters you provided.  When all the stacks have reached the green CREATE_COMPLETE status, as shown in the screenshot following, then the OHDSI architecture has been deployed.  Select the **Outputs** tab to find a link to your OHDSI-Install-Server instances, as shown below.
 
 ![alt-text](images/cfn_output.gif "CloudFormation Output")
 
-6.  You will now see a list of all of your OHDSI-Install-Server instances and you can connect to them using your Remote Desktop client, the username **Administrator** and the password you provided as a parameter. Leave the domain field empty, or use `.\Administrator` if your RDP client requires a local-account prefix. It will take about 5 minutes after this list appears for each OHDSI-Install-Server instance to boot up and for the password to be set. If you connect to your instance and it says the password is incorrect, just wait a few more minutes for the password automation to complete. The template also creates an **ohdsi** local administrator account with the same password.
+1. You will now see a list of all of your OHDSI-Install-Server instances and you can connect to them using your Remote Desktop client, the username **Administrator** and the password you provided as a parameter. Leave the domain field empty, or use `.\Administrator` if your RDP client requires a local-account prefix. The template also creates an **ohdsi** local administrator account with the same password.
 
-7.  Once you are finished with your OHDSI-Install-Server instances, just return to the AWS CloudFormation console and **Delete** the stack, as shown below.  This will terminate all of the instances you launched.
+2. Once you are finished with your OHDSI-Install-Server instances, just return to the AWS CloudFormation console and **Delete** the stack, as shown below.  This will terminate all of the instances you launched.
 
 ![alt-text](images/delete_stack.gif "Delete Stack")
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The template starts from a clean Windows Server base image. It does not pre-inst
 
 - [PostgreSQL for Windows](https://www.postgresql.org/download/windows/) - use the Windows installer linked from PostgreSQL.
 - [Notepad++ downloads](https://notepad-plus-plus.org/downloads/) - use the current installer, or the course-specific version if required.
-- [The Book of OHDSI](https://ohdsi.github.io/TheBookOfOhdsi/) - reference material for the OHDSI tools and setup workflow.
 
 ## OHDSI-Install-Server deployment instructions
 
@@ -72,7 +71,7 @@ When you've provided appropriate values for the **Parameters**, choose **Next**.
 
 ![alt-text](images/cfn_output.gif "CloudFormation Output")
 
-1. You will now see a list of all of your OHDSI-Install-Server instances and you can connect to them using your Remote Desktop client, the username **Administrator** and the password you provided as a parameter. Leave the domain field empty, or use `.\Administrator` if your RDP client requires a local-account prefix. The template also creates an **ohdsi** local administrator account with the same password.
+1. You will now see a list of all of your OHDSI-Install-Server instances and you can connect to them using your Remote Desktop client, the username **Administrator** and the password you provided as a parameter. Leave the domain field empty, or use `.\Administrator` if your RDP client requires a local-account prefix. It will take about 5 minutes after this list appears for each OHDSI-Install-Server instance to boot up and for the password to be set. If you connect to your instance and it says the password is incorrect, just wait a few more minutes for the password automation to complete. The template also creates an **ohdsi** local administrator account with the same password.
 
 2. Once you are finished with your OHDSI-Install-Server instances, just return to the AWS CloudFormation console and **Delete** the stack, as shown below.  This will terminate all of the instances you launched.
 

--- a/ohdsi-install-server.yaml
+++ b/ohdsi-install-server.yaml
@@ -47,7 +47,6 @@ Metadata:
         default: Subnet to deploy the OHDSI-Install-Server instances
 
 
-
 Parameters:
   AccessCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
@@ -98,7 +97,7 @@ Parameters:
   InstancePassword:
     AllowedPattern: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.{8,41}$)[a-zA-Z\d!@#]*$
     ConstraintDescription: 'Must have a length of 8-41 and be letters (upper and lower), at least 1 number, and optionally these special characters !@#'
-    Description: '[ Required ] This password will be used for the "ohdsi" user account of all of the deployed instances.  It must have a length of 8-41 and be letters (upper and lower), at least one number, and optionally these special characters !@#'
+    Description: '[ Required ] This password will be used for the "Administrator" and "ohdsi" user accounts of all of the deployed instances.  It must have a length of 8-41 and be letters (upper and lower), at least one number, and optionally these special characters !@#'
     MaxLength: 41
     MinLength: 8
     Type: String
@@ -110,42 +109,6 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
     Description: '[ Required ] The VPC that will be used for the OHDSI-Install-Server instances'
 
-
-#Mapping to find the OHDSI-Install-Server AMI in each region.
-Mappings:
-  RegionMap:
-#    us-east-1:
-#      AMI: ami-0e3cf331376d436a6
-#    us-east-2:
-#      AMI:
-#    us-west-1:
-#      AMI:
-#    us-west-2:
-#      AMI:
-#    ca-central-1:
-#      AMI:
-    eu-west-1:
-      AMI: ami-0a895af789dd30705
-#    eu-west-2:
-#      AMI:
-#    eu-west-3:
-#      AMI:
-#    eu-central-1:
-#      AMI:
-#    sa-east-1:
-#      AMI:
-#    ap-south-1:
-#      AMI:
-#    ap-southeast-1:
-#      AMI:
-#    ap-southeast-2:
-#      AMI:
-#    ap-northeast-1:
-#      AMI: ami-03386267e7d031671
-#    ap-northeast-2:
-#      AMI:
-#    ap-northeast-3:
-#      AMI:
 
 Resources:
   RDPSG:
@@ -167,10 +130,7 @@ Resources:
     Type: Custom::EC2Instances
     Properties:
       ServiceToken: !GetAtt EC2InstancesFunction.Arn
-      ImageId: !FindInMap
-        - RegionMap
-        - !Ref 'AWS::Region'
-        - AMI
+      ImageId: ami-0a633e85cc83c8862
       InstanceType: !Ref InstanceType
       MinCount: !Ref NumberofInstances
       MaxCount: !Ref NumberofInstances
@@ -188,7 +148,8 @@ Resources:
           echo extend >> C:\diskpart.txt
           diskpart /s C:\diskpart.txt
           net user Administrator ${InstancePassword}
-          net user ohdsi ${InstancePassword}
+          net user ohdsi ${InstancePassword} || net user ohdsi ${InstancePassword} /add
+          net localgroup Administrators ohdsi /add
           </script>
       TagSpecifications:
         - ResourceType: "instance"
@@ -203,36 +164,61 @@ Resources:
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:
         ZipFile: !Sub |
-          var response = require('cfn-response');
-          var AWS = require('aws-sdk');
-          exports.handler = function(event, context) {
-            var physicalId = event.PhysicalResourceId || 'none';
+          const response = require('cfn-response');
+          const {
+            EC2Client,
+            RunInstancesCommand,
+            TerminateInstancesCommand,
+            waitUntilInstanceRunning,
+            waitUntilInstanceTerminated
+          } = require('@aws-sdk/client-ec2');
+
+          exports.handler = async function(event, context) {
+            let physicalId = event.PhysicalResourceId || 'none';
+            const ec2 = new EC2Client({});
+
             function success(data) {
               return response.send(event, context, response.SUCCESS, data, physicalId);
             }
+
             function failed(e) {
-              return response.send(event, context, response.FAILED, e, physicalId);
+              return response.send(event, context, response.FAILED, {Error: e.message || String(e)}, physicalId);
             }
-            var ec2 = new AWS.EC2();
-            var instances;
-            if (event.RequestType == 'Create') {
-              var launchParams = event.ResourceProperties;
-              delete launchParams.ServiceToken;
-              ec2.runInstances(launchParams).promise().then((data)=> {
-                instances = data.Instances.map((data)=> data.InstanceId);
+
+            try {
+              if (event.RequestType == 'Create') {
+                const launchParams = {...event.ResourceProperties};
+                delete launchParams.ServiceToken;
+
+                const data = await ec2.send(new RunInstancesCommand(launchParams));
+                const instances = data.Instances.map((instance) => instance.InstanceId);
                 physicalId = instances.join(':');
-                return ec2.waitFor('instanceRunning', {InstanceIds: instances}).promise();
-              }).then((data)=> success({Instances: instances})
-              ).catch((e)=> failed(e));
-            } else if (event.RequestType == 'Delete') {
-              if (physicalId == 'none') {return success({});}
-              var deleteParams = {InstanceIds: physicalId.split(':')};
-              ec2.terminateInstances(deleteParams).promise().then((data)=>
-                ec2.waitFor('instanceTerminated', deleteParams).promise()
-              ).then((data)=>success({})
-              ).catch((e)=>failed(e));
-            } else {
-              return failed({Error: "In-place updates not supported."});
+
+                await waitUntilInstanceRunning(
+                  {client: ec2, maxWaitTime: 240},
+                  {InstanceIds: instances}
+                );
+                return success({Instances: instances});
+              } else if (event.RequestType == 'Delete') {
+                if (physicalId == 'none') {return success({});}
+
+                const instanceIds = physicalId
+                  .split(':')
+                  .filter((id) => /^i-[a-z0-9]+$/.test(id));
+                if (instanceIds.length == 0) {return success({});}
+
+                const deleteParams = {InstanceIds: instanceIds};
+                await ec2.send(new TerminateInstancesCommand(deleteParams));
+                await waitUntilInstanceTerminated(
+                  {client: ec2, maxWaitTime: 240},
+                  deleteParams
+                );
+                return success({});
+              } else {
+                return failed(new Error("In-place updates not supported."));
+              }
+            } catch (e) {
+              return failed(e);
             }
           };
       Runtime: nodejs24.x
@@ -265,4 +251,4 @@ Resources:
 
 Outputs:
   OHDSIinaBoxInstances:
-    Value: !Join ['', ['https://', !Ref 'AWS::Region', '.console.aws.amazon.com/ec2/v2/home?region=', !Ref 'AWS::Region', '#Instances:search=', !Sub 'OHDSIinaBox-${AWS::StackName}']]
+    Value: !Join ['', ['https://', !Ref 'AWS::Region', '.console.aws.amazon.com/ec2/v2/home?region=', !Ref 'AWS::Region', '#Instances:search=', !Sub 'OHDSIInstallServer-${AWS::StackName}']]

--- a/ohdsi-install-server.yaml
+++ b/ohdsi-install-server.yaml
@@ -235,7 +235,7 @@ Resources:
               return failed({Error: "In-place updates not supported."});
             }
           };
-      Runtime: nodejs12.x
+      Runtime: nodejs24.x
       Timeout: 300
   LambdaExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Summary

- Update the custom resource Lambda implementation for the Node.js 24 runtime by using AWS SDK for JavaScript v3
- Replace the unavailable legacy OHDSI AMI mapping with the Amazon Windows Server 2025 Full Base AMI used during validation
- Harden custom-resource delete handling when CloudFormation supplies a placeholder physical ID after a failed create
- Create the local `ohdsi` administrator account during Windows user-data execution
- Update the README to document the Windows Server base image, Administrator login, and manual installation links for PostgreSQL, Notepad++, and OHDSI setup material
- Fix the EC2 console output search string to match the instance Name tag

## Why

Deployments with the previous Lambda runtime update failed because Node.js 24 does not provide the old `aws-sdk` v2 module. The Lambda failed during initialization with `Cannot find module 'aws-sdk'`, before it could send a CloudFormation custom-resource response. The previous AMI ID also failed with `Not authorized for images`, so this switches to a current Amazon-owned Windows Server 2025 base AMI.

This is related to #4. This branch includes the runtime update because the Lambda code change depends on a supported Node.js runtime.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('ohdsi-install-server.yaml'); puts 'yaml ok'"`
- `git diff --check`
- `aws cloudformation validate-template --region eu-west-1 --template-body file://ohdsi-install-server.yaml`
- `aws ec2 describe-images --region eu-west-1 --image-ids ami-0a633e85cc83c8862` confirmed `Windows_Server-2025-English-Full-Base-2026.06.10`
